### PR TITLE
Update BaseTest.cs

### DIFF
--- a/test/FrameworkCoreTest/BaseTest.cs
+++ b/test/FrameworkCoreTest/BaseTest.cs
@@ -53,7 +53,7 @@ namespace FrameworkCoreTest
 
         private string GetToken()
         {
-            var token = GetCurrentToken();
+            var token = ApiAccessTokenManager.Instance.GetCurrentToken();
             var expirtime = ApiAccessTokenManager.Instance.ExpireTime;
             File.WriteAllText(tokenfile, token + "|" + expirtime.ToString(), Encoding.UTF8);
 


### PR DESCRIPTION
GetToken()方法中，读取token的方法不对，应该从ApiAccessTokenManager中读取。
